### PR TITLE
Table - Hotfixes pressing cancel bug on list selector / Enables one click selection of list items

### DIFF
--- a/src/main/java/se/uog/table/ListSelectorDialog.java
+++ b/src/main/java/se/uog/table/ListSelectorDialog.java
@@ -7,6 +7,7 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -37,6 +38,7 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
     private static ListSelectorDialog dialog;
     private static List<?> selection;
     private JList<?> list;
+    private DefaultListModel<?> listModel;
 
     public static List<?> showDialog(Component owner, String dialogTitle, DefaultListModel<?> model,
             List<?> initalSelection) {
@@ -53,14 +55,25 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
         // Set the current selection
         ListSelectorDialog.selection = selection;
         list.clearSelection();
+
+        // Set the selection to match the selection.
+        Iterator iterator = selection.iterator();
+        while (iterator.hasNext()) {
+            int index = listModel.indexOf(iterator.next());
+            if (index >= 0) {
+                list.addSelectionInterval(index, index);
+            }
+        }
     }
 
     private ListSelectorDialog(Frame frame, String dialogTitle, DefaultListModel<?> listModel,
             List<?> initalSelection) {
         super(frame, dialogTitle, true);
 
+        this.listModel = listModel;
+
         // Create and initialize the buttons.
-        JButton cancelButton = new JButton("Cancel");
+        JButton cancelButton = new JButton("Clear");
         cancelButton.addActionListener(this);
         //
         final JButton setButton = new JButton("Set");

--- a/src/main/java/se/uog/table/ListSelectorDialog.java
+++ b/src/main/java/se/uog/table/ListSelectorDialog.java
@@ -102,7 +102,7 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
 
             @Override
             public void setValueIsAdjusting(boolean isAdjusting) {
-                if (isAdjusting == false) {
+                if (!isAdjusting) {
                     gestureStarted = false;
                 }
             }

--- a/src/main/java/se/uog/table/ListSelectorDialog.java
+++ b/src/main/java/se/uog/table/ListSelectorDialog.java
@@ -23,22 +23,17 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 
-// TODO: Bug fix on cancel return value
 /**
  * A singleton class which displays a pop-up dialog for selecting elements from
  * a DefaultListModel.
  */
 public class ListSelectorDialog extends JDialog implements ActionListener {
-
-    /**
-     * Default serial.
-     */
     private static final long serialVersionUID = 1L;
 
     private static ListSelectorDialog dialog;
     private static List<?> selection;
-    private JList<?> list;
     private DefaultListModel<?> listModel;
+    private JList<?> list;
 
     public static List<?> showDialog(Component owner, String dialogTitle, DefaultListModel<?> model,
             List<?> initalSelection) {
@@ -54,9 +49,11 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
     private void setSelection(List<?> selection) {
         // Set the current selection
         ListSelectorDialog.selection = selection;
+
+        // Update the view accordingly
         list.clearSelection();
 
-        // Set the selection to match the selection.
+        // Toggle selection on each item
         Iterator iterator = selection.iterator();
         while (iterator.hasNext()) {
             int index = listModel.indexOf(iterator.next());

--- a/src/main/java/se/uog/table/ListSelectorDialog.java
+++ b/src/main/java/se/uog/table/ListSelectorDialog.java
@@ -7,12 +7,13 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Iterator;
 import java.util.List;
+
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultListModel;
+import javax.swing.DefaultListSelectionModel;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JList;
@@ -21,10 +22,10 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 
-
 // TODO: Bug fix on cancel return value
 /**
- * A singleton class which displays a pop-up dialog for selecting elements from a DefaultListModel.
+ * A singleton class which displays a pop-up dialog for selecting elements from
+ * a DefaultListModel.
  */
 public class ListSelectorDialog extends JDialog implements ActionListener {
 
@@ -49,15 +50,9 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
     }
 
     private void setSelection(List<?> selection) {
-
+        // Set the current selection
+        ListSelectorDialog.selection = selection;
         list.clearSelection();
-
-        Iterator<?> iterator = selection.iterator();
-
-        while (iterator.hasNext()) {
-            list.setSelectedValue(iterator.next(), false);
-        }
-
     }
 
     private ListSelectorDialog(Frame frame, String dialogTitle, DefaultListModel<?> listModel,
@@ -75,6 +70,34 @@ public class ListSelectorDialog extends JDialog implements ActionListener {
 
         // main part of the dialog
         list = new JList(listModel);
+
+        // Code taken from:
+        // Allows single click (de)selection of a list
+        // https://stackoverflow.com/questions/2528344/jlist-deselect-when-clicking-an-already-selected-item
+        list.setSelectionModel(new DefaultListSelectionModel() {
+
+            boolean gestureStarted = false;
+
+            @Override
+            public void setSelectionInterval(int index0, int index1) {
+                if (!gestureStarted) {
+                    if (isSelectedIndex(index0)) {
+                        super.removeSelectionInterval(index0, index1);
+                    } else {
+                        super.addSelectionInterval(index0, index1);
+                    }
+                }
+                gestureStarted = true;
+            }
+
+            @Override
+            public void setValueIsAdjusting(boolean isAdjusting) {
+                if (isAdjusting == false) {
+                    gestureStarted = false;
+                }
+            }
+        });
+        // End code from source
 
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         list.setLayoutOrientation(JList.VERTICAL);

--- a/src/main/java/se/uog/table/ObjectTableListSelector.java
+++ b/src/main/java/se/uog/table/ObjectTableListSelector.java
@@ -53,14 +53,9 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor implements
 
     // Change if something is selected, otherwise,
     private void changeSelection(List<L> selection) {
-
-        System.out.println("changeSelectionIn: " + selection);
         if (selection != null) {
             this.selectedItems = selection;
         }
-        System.out.println("changeSelectionOut: " + selectedItems);
-
-        System.out.println("after fire: " + selectedItems);
         stopCellEditing();
     }
 
@@ -91,10 +86,7 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor implements
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        System.out.println(selectedItems);
         List<L> selection = (List<L>) ListSelectorDialog.showDialog(delegate, dialogTitle, filteredList, selectedItems);
-
-        System.out.println("Selection return: " + selection);
         changeSelection(selection);
     }
 

--- a/src/main/java/se/uog/table/ObjectTableListSelector.java
+++ b/src/main/java/se/uog/table/ObjectTableListSelector.java
@@ -52,10 +52,15 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor implements
     }
 
     // Change if something is selected, otherwise,
-    private void changeSelection(List<L> selectedItems) {
-        if (selectedItems != null) {
-            this.selectedItems = selectedItems;
+    private void changeSelection(List<L> selection) {
+
+        System.out.println("changeSelectionIn: " + selection);
+        if (selection != null) {
+            this.selectedItems = selection;
         }
+        System.out.println("changeSelectionOut: " + selectedItems);
+
+        System.out.println("after fire: " + selectedItems);
         stopCellEditing();
     }
 
@@ -86,7 +91,10 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor implements
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        System.out.println(selectedItems);
         List<L> selection = (List<L>) ListSelectorDialog.showDialog(delegate, dialogTitle, filteredList, selectedItems);
+
+        System.out.println("Selection return: " + selection);
         changeSelection(selection);
     }
 

--- a/src/main/java/se/uog/table/ObjectTableListSelector.java
+++ b/src/main/java/se/uog/table/ObjectTableListSelector.java
@@ -13,12 +13,11 @@ import javax.swing.JTable;
 import javax.swing.table.TableCellEditor;
 
 /**
- * 
+ *
  * @param <T> The Table element class
  * @param <L> The List element class
  */
-public class ObjectTableListSelector<T, L> extends AbstractCellEditor
-        implements TableCellEditor, ActionListener {
+public class ObjectTableListSelector<T, L> extends AbstractCellEditor implements TableCellEditor, ActionListener {
 
     private JButton delegate = new JButton("editing...");
 
@@ -33,17 +32,15 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor
     // Defaults to null as it is not needed.
     private DefaultListModel<T> tableElementList = null;
     // Filter function just returns original listElementList;
-    private BiFunction<List<L>, T, List<L>> filterFunction =
-            (listElementList, tableElement) -> listElementList;
+    private BiFunction<List<L>, T, List<L>> filterFunction = (listElementList, tableElement) -> listElementList;
 
     public ObjectTableListSelector(DefaultListModel<L> listElementList, String dialogTitle) {
         // Defaults to no filter function
         this(listElementList, null, dialogTitle, (targetList, tableElement) -> targetList);
     }
 
-    public ObjectTableListSelector(DefaultListModel<L> listElementList,
-            DefaultListModel<T> tableElementList, String dialogTitle,
-            BiFunction<List<L>, T, List<L>> filterFunction) {
+    public ObjectTableListSelector(DefaultListModel<L> listElementList, DefaultListModel<T> tableElementList,
+            String dialogTitle, BiFunction<List<L>, T, List<L>> filterFunction) {
 
         this.listElementList = listElementList;
         this.tableElementList = tableElementList;
@@ -59,7 +56,6 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor
         if (selectedItems != null) {
             this.selectedItems = selectedItems;
         }
-
         stopCellEditing();
     }
 
@@ -70,8 +66,10 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor
     }
 
     @Override
-    public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected,
-            int row, int column) {
+    public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+
+        // Set the initial values to the values in the table cell...
+        changeSelection((List<L>) value);
 
         T currentTableRowElement = null;
         // Get the current table element for filtering etc.
@@ -79,8 +77,8 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor
             currentTableRowElement = tableElementList.get(row);
         }
         // Filter the listElementList based on the provided function
-        filteredList = convertListToDefaultListModel(filterFunction
-                .apply(convertDefaultListModelToList(listElementList), currentTableRowElement));
+        filteredList = convertListToDefaultListModel(
+                filterFunction.apply(convertDefaultListModelToList(listElementList), currentTableRowElement));
 
         // Show the 'editing...' button in the window while the dialog is open
         return delegate;
@@ -88,11 +86,7 @@ public class ObjectTableListSelector<T, L> extends AbstractCellEditor
 
     @Override
     public void actionPerformed(ActionEvent e) {
-
-        // OPEN THE LIST SELECTOR HERE
-        List<L> selection = (List<L>) ListSelectorDialog.showDialog(delegate, dialogTitle,
-                filteredList, selectedItems);
-
+        List<L> selection = (List<L>) ListSelectorDialog.showDialog(delegate, dialogTitle, filteredList, selectedItems);
         changeSelection(selection);
     }
 


### PR DESCRIPTION
There was a bug where clicking cancel dumped the last list selection (even if it was from another row) into the current cell. Fixed.

Added multiple click selection of items.